### PR TITLE
fix(yolov8): correct tensor indices for box/cls in multi-output postprocess

### DIFF
--- a/sscma/core/model/ma_model_yolov8.cpp
+++ b/sscma/core/model/ma_model_yolov8.cpp
@@ -174,7 +174,7 @@ ma_err_t YoloV8::postProcessF32() {
         int grid_l          = grid_h * grid_w;
         int stride          = img_.height / grid_h;
         float* output_score = outputs_[i + 3].data.f32;
-        float* output_box   = outputs_[i + 3].data.f32;
+        float* output_box   = outputs_[i].data.f32;
         for (int j = 0; j < grid_h; j++) {
             for (int k = 0; k < grid_w; k++) {
                 int offset = j * grid_w + k;

--- a/sscma/core/model/ma_model_yolov8.cpp
+++ b/sscma/core/model/ma_model_yolov8.cpp
@@ -31,7 +31,12 @@ YoloV8::YoloV8(Engine* p_engine_) : Detector(p_engine_, "YoloV8", MA_MODEL_TYPE_
     int s = w >> 5, m = w >> 4, l = w >> 3;
 
     num_record_ = (s * s + m * m + l * l);
-    num_class_  = outputs_[1].shape.dims[1];
+    // Cls tensor lives at outputs_[3..5] in the grouped (box×3 + cls×3) layout
+    // checked by isValid(). outputs_[1] is the second box DFL tensor with
+    // dims[1]=64 (DFL bins ×4 coords) — using it as num_class_ caused the
+    // postProcess loops to read 64 channels from a (often) 1-channel cls
+    // tensor, producing thousands of false-positives from out-of-bounds reads.
+    num_class_  = outputs_[3].shape.dims[1];
 }
 
 YoloV8::~YoloV8() {}


### PR DESCRIPTION
## Summary

Two related tensor-index bugs in the YoloV8 multi-output (6-output, grouped layout) detector that completely break detection for any 6-output cvimodel except COCO-80 (and even there silently drops 16 classes).

The 6-output grouped layout, validated by \`YoloV8::isValid()\` at sscma/core/model/ma_model_yolov8.cpp:67-79, is:
- \`outputs_[0..2]\` — box DFL tensors (\`dims[1]==64\` = 4 coords × 16 DFL bins)
- \`outputs_[3..5]\` — cls tensors (\`dims[1]==num_classes\`)

### Bug 1 — F32 postprocess: \`output_box\` pointed at cls tensor (commit 068d936)

\`postProcessF32()\` had \`output_box = outputs_[i + 3].data.f32\` (cls tensor) instead of \`outputs_[i].data.f32\` (box DFL tensor). Both \`output_score\` and \`output_box\` resolved to the same 1-channel cls buffer, so the DFL decode loop read 64 channels of garbage from a single-channel buffer.

The INT8 path at L110-111 was already correct (\`outputs_[i]\` for box) — this was a typo on the F32 side only.

### Bug 2 — Constructor: \`num_class_\` taken from box tensor (commit 759acfb)

The constructor at L34 set \`num_class_ = outputs_[1].shape.dims[1]\`. Since \`outputs_[1]\` is a box tensor with \`dims[1]==64\` (always), \`num_class_\` was hardcoded to 64 regardless of the actual model's class count.

Effect:
- 1-class models (e.g. face): postProcess loop reads 64 channels from a 1-channel cls tensor → out-of-bounds reads into adjacent tensor memory → garbage scores produce thousands of false-positive detections per frame
- COCO-80: silently drops detections of classes 64-79 (truck, kite, clock, …)
- Any model where \`num_classes != 64\`: broken in some way

YOLO11 uses an interleaved \`(box, cls) × 3\` layout, so \`outputs_[1]\` correctly points to the first cls tensor — \`ma_model_yolo11.cpp\` is unaffected by this bug.

## Reproduction

Tested on Seeed reCamera (CV181x SoC) with a 1-class yolov8n-face cvimodel exported with raw 6-output detect head:

| | Before | After |
|---|---|---|
| face_count | 2866/frame | 1/frame |
| detect | 4641 ms | 48-84 ms |
| analyze (downstream attribute analyzer) | 327 s/frame | 10-301 ms/frame |

Service was effectively dead before the fix (~5 minute per-frame pipeline). After the fix it matches the legacy single-output (YoloSingle internal-NMS) baseline.

## Test plan

- [x] On-device end-to-end with 1-class yolov8n-face cvimodel (face detection)
- [ ] On-device verification with COCO-80 yolov8n cvimodel — would expect classes 64-79 to start being detected
- [ ] Unit test for \`YoloV8::isValid()\` layout assumptions (suggested follow-up — not in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)