### PR TITLE
fix(yolo): swap quant_param indices for box/cls in INT8 multi-output postprocess (yolov8 + yolo11)

### DIFF
--- a/sscma/core/model/ma_model_yolo11.cpp
+++ b/sscma/core/model/ma_model_yolo11.cpp
@@ -126,14 +126,18 @@ ma_err_t Yolo11::postProcessI8() {
                 if (target < 0)
                     continue;
 
-                float score = ma::math::dequantizeValue(max, outputs_[i * 2].quant_param.scale, outputs_[i * 2].quant_param.zero_point);
+                // Class tensor is outputs_[i*2 + 1]; box DFL tensor is outputs_[i*2].
+                // Previously these were swapped, producing NaN coords on INT8 (exp(huge_dequant)) and
+                // garbled scores that flooded NMS with duplicates. Match the (correct) layout used in
+                // ma_model_yolo26.cpp.
+                float score = ma::math::dequantizeValue(max, outputs_[i * 2 + 1].quant_param.scale, outputs_[i * 2 + 1].quant_param.zero_point);
 
                 if (score > score_threshold_non_sigmoid) {
                     float rect[4];
                     float before_dfl[dfl_len * 4];
                     offset = j * grid_w + k;
                     for (int b = 0; b < dfl_len * 4; b++) {
-                        before_dfl[b] = ma::math::dequantizeValue(output_box[offset], outputs_[i * 2 + 1].quant_param.scale, outputs_[i * 2 + 1].quant_param.zero_point);
+                        before_dfl[b] = ma::math::dequantizeValue(output_box[offset], outputs_[i * 2].quant_param.scale, outputs_[i * 2].quant_param.zero_point);
                         offset += grid_l;
                     }
                     compute_dfl(before_dfl, dfl_len, rect);

--- a/sscma/core/model/ma_model_yolov8.cpp
+++ b/sscma/core/model/ma_model_yolov8.cpp
@@ -127,14 +127,17 @@ ma_err_t YoloV8::postProcessI8() {
                 if (target < 0)
                     continue;
 
-                float score = ma::math::dequantizeValue(max, outputs_[i].quant_param.scale, outputs_[i].quant_param.zero_point);
+                // Class tensor lives at outputs_[i + 3] (grouped layout: 3 box + 3 cls);
+                // box DFL tensor lives at outputs_[i]. Previously these were swapped, producing
+                // NaN coords on INT8 and garbled scores. Match the (correct) Yolo26 layout.
+                float score = ma::math::dequantizeValue(max, outputs_[i + 3].quant_param.scale, outputs_[i + 3].quant_param.zero_point);
 
                 if (score > score_threshold_non_sigmoid) {
                     float rect[4];
                     float before_dfl[dfl_len * 4];
                     offset = j * grid_w + k;
                     for (int b = 0; b < dfl_len * 4; b++) {
-                        before_dfl[b] = ma::math::dequantizeValue(output_box[offset], outputs_[i + 3].quant_param.scale, outputs_[i + 3].quant_param.zero_point);
+                        before_dfl[b] = ma::math::dequantizeValue(output_box[offset], outputs_[i].quant_param.scale, outputs_[i].quant_param.zero_point);
                         offset += grid_l;
                     }
                     compute_dfl(before_dfl, dfl_len, rect);


### PR DESCRIPTION
## Summary

The INT8 postprocess path in \`ma_model_yolov8.cpp\` and \`ma_model_yolo11.cpp\` used the wrong \`quant_param\` for dequantizing scores and DFL box deltas, swapping the cls and box tensor parameters. Because cls and box tensors typically have very different INT8 scales (often 128–512× apart), the wrong scale on the DFL path causes \`exp()\` to overflow during DFL softmax → NaN/Inf coordinates → SEGV in downstream cropping (or, on more forgiving paths, garbled detections that flood NMS with duplicates).

### YoloV8 (grouped layout: box×3 + cls×3)

In \`ma_model_yolov8.cpp::postProcessS8()\`:
- score dequant should use \`outputs_[i + 3].quant_param\` (cls)
- box DFL dequant should use \`outputs_[i].quant_param\` (box)

Previously these were swapped.

### YOLO11 (interleaved layout: (box, cls) × 3)

In \`ma_model_yolo11.cpp::postProcessS8()\`:
- score dequant should use \`outputs_[i*2 + 1].quant_param\` (cls)
- box DFL dequant should use \`outputs_[i*2].quant_param\` (box)

Previously these were swapped.

The YOLO26 implementation at \`ma_model_yolo26.cpp:181-189\` already uses the correct (box → box.quant_param, cls → cls.quant_param) pattern; this PR aligns the V8/V11 paths with that reference.

## Reproduction

On Seeed reCamera (CV181x) with INT8 yolov11n-face cvimodel:
- Before fix: \`detect = 8000–9500 ms\`, 7–10 fixed bboxes per frame with stair-stepped \`sigmoid(saturated_logit)\` confidences (1.000 / 0.838 / 0.707 / 0.500 …) — DFL box reads were treated through cls's tiny scale, then re-scaled through box's large scale at the wrong layer, saturating logits.
- After fix: detection produces sane coordinates and no NaN/Inf is observed in box decode.

This bug is independent of the 6-output tensor-index bugs in PR #99 — that one mis-indexes the tensor pointers themselves; this one mis-indexes the \`quant_param\` of the (correctly indexed) tensors.

## Test plan

- [x] Verified no NaN/Inf coords on yolov11n-face INT8 cvimodel after fix
- [x] Verified production detection on yolov8n-face INT8 cvimodel after fix (paired with PR #99)
- [ ] Suggested follow-up: unit test exercising mismatched cls/box scales (e.g. cls scale ≈ 0.43, box scale ≈ 256) to guard against future regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)